### PR TITLE
Fix --offload_diffusion_transformer and multi-GPU error

### DIFF
--- a/assets/sample_av_hdmap_spec.json
+++ b/assets/sample_av_hdmap_spec.json
@@ -1,6 +1,6 @@
 {
     "hdmap": {
         "control_weight": 1,
-        "input_control": "examples/sample_av_multi_control/input_hdmap.mp4"
+        "input_control": "assets/sample_av_multi_control_input_hdmap.mp4"
     }
 }

--- a/cosmos_transfer1/diffusion/inference/transfer.py
+++ b/cosmos_transfer1/diffusion/inference/transfer.py
@@ -228,12 +228,10 @@ def demo(cfg, control_inputs):
         offload_prompt_upsampler=cfg.offload_prompt_upsampler,
     )
 
+    # Set process group for context parallelism if using multiple GPUs
     if cfg.num_gpus > 1:
-        pipeline.model.model.net.enable_context_parallel(process_group)
-        pipeline.model.model.base_model.net.enable_context_parallel(process_group)
-        if hasattr(pipeline.model.model, "hint_encoders"):
-            pipeline.model.model.hint_encoders.net.enable_context_parallel(process_group)
-
+        pipeline.process_group = process_group
+        
     # Handle multiple prompts if prompt file is provided
     if cfg.batch_input_path:
         log.info(f"Reading batch inputs from path: {cfg.batch_input_path}")


### PR DESCRIPTION
Moves enabling context parallelism into `_load_network` to resolve error attempting to access the network when multi GPU and `--offload_diffusion_transformer` is enabled.